### PR TITLE
Update build_wmc.py

### DIFF
--- a/build_wmc.py
+++ b/build_wmc.py
@@ -22,7 +22,7 @@ def build_wmc(tck_file, tractID_list):
     labels = np.zeros((len(tractogram),1))
     #os.makedirs('tracts')
     tractsfile = []
-    names = np.full(tractID_list[-1],'NC',dtype=object)
+    names = np.full(len(tractID_list),'NC',dtype=object)
     
     with open('tract_name_list.txt') as f:
     	tract_name_list = f.read().splitlines()


### PR DESCRIPTION
Hey Giulia,

The build_wmc.py code has a bug in it. If you enter a list of tractIDs that is not a sequence of 1:(last tract ID name), you'll get a resulting classification structure that are empty. This will cause errors with tract profiles.

I modified the code to generate an empty classification structure that is the same length as the number of inputted tractIDs, instead of an array with length of 1:last ID in the tractIDs list.

Haven't fully tested with actual data, but it should work.

Great app!
Brad